### PR TITLE
Fix import error for backup dags without xcom or task instance

### DIFF
--- a/assets/dags/mwaa_dr/framework/factory/base_dr_factory.py
+++ b/assets/dags/mwaa_dr/framework/factory/base_dr_factory.py
@@ -345,7 +345,7 @@ class BaseDRFactory(ABC):
 
             try:
                 export_tasks["xcom"] >> export_tasks["task_instance"]
-            except KeyError: # Missing xcom or task instance task
+            except KeyError:  # Missing xcom or task instance task
                 pass
 
         teardown_t = PythonOperator(

--- a/assets/dags/mwaa_dr/framework/factory/base_dr_factory.py
+++ b/assets/dags/mwaa_dr/framework/factory/base_dr_factory.py
@@ -336,22 +336,17 @@ class BaseDRFactory(ABC):
         with TaskGroup(group_id="export_tables", dag=dag) as export_tables_t:
             export_tasks = {}
             for table in self.tables():
-                if table.name != "xcom":
-                    export_task = PythonOperator(
-                        task_id=f"export_{table.name}s",
-                        python_callable=table.backup,
-                        dag=dag,
-                    )
-                    export_tasks[table.name] = export_task
+                export_task = PythonOperator(
+                    task_id=f"export_{table.name}s",
+                    python_callable=table.backup,
+                    dag=dag,
+                )
+                export_tasks[table.name] = export_task
 
-            xcom_task = PythonOperator(
-                task_id="export_xcoms",
-                python_callable=[
-                    table.backup for table in self.tables() if table.name == "xcom"
-                ][0],
-                dag=dag,
-            )
-            xcom_task >> export_tasks["task_instance"]
+            try:
+                export_tasks["xcom"] >> export_tasks["task_instance"]
+            except KeyError: # Missing xcom or task instance task
+                pass
 
         teardown_t = PythonOperator(
             task_id="teardown", python_callable=self.teardown_backup, dag=dag


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Dependency Update
- [ ] Release

## Description
Custom DAG factories cannot create backup dags unless they include the xcom and task_instance tables.

This PR fixes `create_backup_dag` to catch the KeyError if either xcom or task_instance is not one of the export_tasks.


## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #40
- Closes #40

## Linting

Have you done linting by issuing `./build.sh lint` command?
- [X] Yes
- [ ] No, I need help with linting


## Testing

Have you run testing by issuing `./build.sh unit` command?
- [ ] Yes
- [X] No, I need help with writing tests

## Documentation
Have you updated the [README](../README.md) appropriate for this PR?
- [ ] Yes
- [X] No, README does not need any changes for this PR

## Changelog

Have you updated the [CHANGELOG](../CHANGELOG.md) with the changes you are making in this PR?
Please use Added, Removed, and/or Changed subsections under the [Unreleased](../CHANGELOG.md#unreleased) section.
- [ ] Yes
- [X] No, I need help

## Terms of Contribution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
